### PR TITLE
画像を丸く切り取り、枠を付ける #9

### DIFF
--- a/Shared/Main/Source/Views/Home/HomeView.swift
+++ b/Shared/Main/Source/Views/Home/HomeView.swift
@@ -17,6 +17,9 @@ struct HomeView: View {
                 NavigationLink(destination: ResizeImageAndClipView()) {
                     Text("画像をリサイズして表示(clip)")
                 }
+                NavigationLink(destination: ResizeImageToCircleWithBorderView()) {
+                    Text("画像を丸く切り取り、枠を付ける")
+                }
             }
         }
         .navigationTitle("100本ノック")

--- a/Shared/Main/Source/Views/ResizeImageToCircleWithBorder/ResizeImageToCircleWithBorderView.swift
+++ b/Shared/Main/Source/Views/ResizeImageToCircleWithBorder/ResizeImageToCircleWithBorderView.swift
@@ -1,0 +1,20 @@
+//
+//  ResizeImageToCircleWithBorderView.swift
+//  SwiftUI100Knocks (iOS)
+//
+//  Created by MiharuNaruse on 2022/08/26.
+//
+
+import SwiftUI
+
+struct ResizeImageToCircleWithBorderView: View {
+    var body: some View {
+        Text("Hello, world!")
+    }
+}
+
+struct ResizeImageToCircleWithBorderView_Previews: PreviewProvider {
+    static var previews: some View {
+        ResizeImageToCircleWithBorderView()
+    }
+}

--- a/Shared/Main/Source/Views/ResizeImageToCircleWithBorder/ResizeImageToCircleWithBorderView.swift
+++ b/Shared/Main/Source/Views/ResizeImageToCircleWithBorder/ResizeImageToCircleWithBorderView.swift
@@ -5,11 +5,25 @@
 //  Created by MiharuNaruse on 2022/08/26.
 //
 
+// https://developer.apple.com/documentation/swiftui/view/clipshape(_:style:)
+
+import SDWebImageSwiftUI
 import SwiftUI
 
 struct ResizeImageToCircleWithBorderView: View {
+    private let imageURLString: String = "https://placekitten.com/300/300"
+
     var body: some View {
-        Text("Hello, world!")
+        WebImage(url: URL(string: imageURLString))
+            .onSuccess(perform: { _, _, _ in
+
+            })
+            .placeholder(Image(systemName: "photo"))
+            .indicator(.activity)
+            .transition(.fade(duration: 0.5))
+            .scaledToFill()
+            .frame(width: 150, height: 150, alignment: .top)
+            .clipShape(Circle())
     }
 }
 

--- a/Shared/Main/Source/Views/ResizeImageToCircleWithBorder/ResizeImageToCircleWithBorderView.swift
+++ b/Shared/Main/Source/Views/ResizeImageToCircleWithBorder/ResizeImageToCircleWithBorderView.swift
@@ -24,6 +24,10 @@ struct ResizeImageToCircleWithBorderView: View {
             .scaledToFill()
             .frame(width: 150, height: 150, alignment: .top)
             .clipShape(Circle())
+            .overlay {
+                Circle()
+                    .stroke(.black, lineWidth: 4)
+            }
     }
 }
 

--- a/SwiftUI100Knocks.xcodeproj/project.pbxproj
+++ b/SwiftUI100Knocks.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		280B729E28B83AAD002966AE /* ResizeImageToCircleWithBorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 280B729D28B83AAD002966AE /* ResizeImageToCircleWithBorderView.swift */; };
 		2870F77928B665D100718060 /* ResizeImageToFitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2870F77828B665D100718060 /* ResizeImageToFitView.swift */; };
 		2870F77C28B67A0C00718060 /* ResizeImageAndClipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2870F77B28B67A0C00718060 /* ResizeImageAndClipView.swift */; };
 		460572EB28B535CE00C46366 /* Domain.docc in Sources */ = {isa = PBXBuildFile; fileRef = 460572EA28B535CE00C46366 /* Domain.docc */; };
@@ -69,6 +70,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		280B729D28B83AAD002966AE /* ResizeImageToCircleWithBorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizeImageToCircleWithBorderView.swift; sourceTree = "<group>"; };
 		2870F77828B665D100718060 /* ResizeImageToFitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizeImageToFitView.swift; sourceTree = "<group>"; };
 		2870F77B28B67A0C00718060 /* ResizeImageAndClipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizeImageAndClipView.swift; sourceTree = "<group>"; };
 		460572E728B535CE00C46366 /* Domain.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Domain.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -120,6 +122,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		280B729C28B83A87002966AE /* ResizeImageToCircleWithBorder */ = {
+			isa = PBXGroup;
+			children = (
+				280B729D28B83AAD002966AE /* ResizeImageToCircleWithBorderView.swift */,
+			);
+			path = ResizeImageToCircleWithBorder;
+			sourceTree = "<group>";
+		};
 		2870F77728B665B400718060 /* ResizeImageToFit */ = {
 			isa = PBXGroup;
 			children = (
@@ -215,6 +225,7 @@
 			children = (
 				462034E928B0F09000540D3A /* Home */,
 				2870F77A28B679EC00718060 /* ResizeImageAndClip */,
+				280B729C28B83A87002966AE /* ResizeImageToCircleWithBorder */,
 				2870F77728B665B400718060 /* ResizeImageToFit */,
 			);
 			path = Views;
@@ -455,6 +466,7 @@
 				462034D228B0E46D00540D3A /* HomeView.swift in Sources */,
 				462034D028B0E46D00540D3A /* SwiftUI100KnocksApp.swift in Sources */,
 				2870F77C28B67A0C00718060 /* ResizeImageAndClipView.swift in Sources */,
+				280B729E28B83AAD002966AE /* ResizeImageToCircleWithBorderView.swift in Sources */,
 				2870F77928B665D100718060 /* ResizeImageToFitView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## 変更の概要

- #9 

## なぜこの変更をするのか

- 上記課題を達成するため。

## やったこと

- [x] 150✖︎150サイズに画像をリサイズし、丸く切り取って、表示しました。

## やっていないこと

- 黒い枠をつけること

## 変更内容

- UIの変更ならスクリーンショット

| Home | 新規画面 |
| --- | --- |
| ![Home](https://user-images.githubusercontent.com/35392604/186788029-b13fe583-12c6-49a6-95b0-33cbc1e366c4.png) | ![Circle](https://user-images.githubusercontent.com/35392604/186788024-ebc27a20-b9fa-46cc-98dd-12b6b3c91c75.png) |

## 影響範囲

- なし

## どうやるのか

- 再現手順
    - アプリを実行する。

## 課題

- 悩んでいること
    - 丸く黒い枠をつける方法が分かりませんでした。単純に `.border(.black)` を使うと、四角い枠が表示されてしまいました。

## 備考

- なし
