### PR TITLE
NavigationViewを隠す

### DIFF
--- a/Shared/Main/Source/Views/HideNavigationViewView/HideNavigationViewView.swift
+++ b/Shared/Main/Source/Views/HideNavigationViewView/HideNavigationViewView.swift
@@ -1,0 +1,20 @@
+//
+//  HideNavigationViewView.swift
+//  SwiftUI100Knocks (iOS)
+//
+//  Created by MiharuNaruse on 2022/08/27.
+//
+
+import SwiftUI
+
+struct HideNavigationViewView: View {
+    var body: some View {
+        Text("Hello, world!")
+    }
+}
+
+struct HideNavigationViewView_Previews: PreviewProvider {
+    static var previews: some View {
+        HideNavigationViewView()
+    }
+}

--- a/Shared/Main/Source/Views/HideNavigationViewView/HideNavigationViewView.swift
+++ b/Shared/Main/Source/Views/HideNavigationViewView/HideNavigationViewView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct HideNavigationViewView: View {
     var body: some View {
         Text("Hello, world!")
+            .navigationBarHidden(true)
     }
 }
 

--- a/Shared/Main/Source/Views/Home/HomeView.swift
+++ b/Shared/Main/Source/Views/Home/HomeView.swift
@@ -23,6 +23,9 @@ struct HomeView: View {
                 NavigationLink(destination: ImagesSideBySideView()) {
                     Text("画像を横に等間隔に並べる")
                 }
+                NavigationLink(destination: HideNavigationViewView()) {
+                    Text("NavigationViewを隠す")
+                }
             }
         }
         .navigationTitle("100本ノック")

--- a/SwiftUI100Knocks.xcodeproj/project.pbxproj
+++ b/SwiftUI100Knocks.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		280B729E28B83AAD002966AE /* ResizeImageToCircleWithBorderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 280B729D28B83AAD002966AE /* ResizeImageToCircleWithBorderView.swift */; };
+		2821269E28B9BFF900053CEF /* HideNavigationViewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2821269D28B9BFF900053CEF /* HideNavigationViewView.swift */; };
 		2870F77928B665D100718060 /* ResizeImageToFitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2870F77828B665D100718060 /* ResizeImageToFitView.swift */; };
 		2870F77C28B67A0C00718060 /* ResizeImageAndClipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2870F77B28B67A0C00718060 /* ResizeImageAndClipView.swift */; };
 		287D25BA28B8FDB90000A5B7 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 287D25B928B8FDB90000A5B7 /* Localizable.strings */; };
@@ -75,6 +76,7 @@
 
 /* Begin PBXFileReference section */
 		280B729D28B83AAD002966AE /* ResizeImageToCircleWithBorderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizeImageToCircleWithBorderView.swift; sourceTree = "<group>"; };
+		2821269D28B9BFF900053CEF /* HideNavigationViewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HideNavigationViewView.swift; sourceTree = "<group>"; };
 		2870F77828B665D100718060 /* ResizeImageToFitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizeImageToFitView.swift; sourceTree = "<group>"; };
 		2870F77B28B67A0C00718060 /* ResizeImageAndClipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResizeImageAndClipView.swift; sourceTree = "<group>"; };
 		287D25B928B8FDB90000A5B7 /* Localizable.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = Localizable.strings; sourceTree = "<group>"; };
@@ -136,6 +138,14 @@
 				280B729D28B83AAD002966AE /* ResizeImageToCircleWithBorderView.swift */,
 			);
 			path = ResizeImageToCircleWithBorder;
+			sourceTree = "<group>";
+		};
+		2821269C28B9BFDF00053CEF /* HideNavigationViewView */ = {
+			isa = PBXGroup;
+			children = (
+				2821269D28B9BFF900053CEF /* HideNavigationViewView.swift */,
+			);
+			path = HideNavigationViewView;
 			sourceTree = "<group>";
 		};
 		2870F77728B665B400718060 /* ResizeImageToFit */ = {
@@ -249,6 +259,7 @@
 		462034E728B0F03500540D3A /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				2821269C28B9BFDF00053CEF /* HideNavigationViewView */,
 				462034E928B0F09000540D3A /* Home */,
 				287D25C028B8FF330000A5B7 /* ImagesSideBySide */,
 				2870F77A28B679EC00718060 /* ResizeImageAndClip */,
@@ -516,6 +527,7 @@
 				2870F77C28B67A0C00718060 /* ResizeImageAndClipView.swift in Sources */,
 				287D25C228B8FF7F0000A5B7 /* ImagesSideBySideView.swift in Sources */,
 				287D25BF28B8FEA60000A5B7 /* Assets-Constants.swift in Sources */,
+				2821269E28B9BFF900053CEF /* HideNavigationViewView.swift in Sources */,
 				280B729E28B83AAD002966AE /* ResizeImageToCircleWithBorderView.swift in Sources */,
 				287D25BE28B8FEA60000A5B7 /* L10n-Constants.swift in Sources */,
 				2870F77928B665D100718060 /* ResizeImageToFitView.swift in Sources */,


### PR DESCRIPTION
## 変更の概要

- Closes #13 

## なぜこの変更をするのか

- 上記課題を達成するため。

## やったこと

- [x] NavigationViewを隠す。

## 変更内容

- UIの変更ならスクリーンショット

| Home | 新しい画面 |
| --- | --- |
| ![Home](https://user-images.githubusercontent.com/35392604/187012302-29b445a4-67ad-4771-9e75-b32741c0cc3a.png) | ![Bar](https://user-images.githubusercontent.com/35392604/187012300-b9b9f3dc-86f9-4bfa-9e4a-266d48fb335e.png)|

## 影響範囲

- ユーザに影響すること
    - 一度HideNavigationViewView画面に画面遷移したら、Home画面に戻れないので、アプリを一度キルしてください。

## どうやるのか

- 再現手順
    - アプリを実行する。

## 課題

- なし

## 備考

- iOS 16.0+ から deprecated です。
    - https://developer.apple.com/documentation/swiftui/modifiedcontent/navigationbarhidden(_:)