### PR TITLE
画面遷移時に値を渡す

### DIFF
--- a/Domain/Model/Fluit.swift
+++ b/Domain/Model/Fluit.swift
@@ -1,0 +1,16 @@
+//
+//  Fluit.swift
+//  Domain
+//
+//  Created by 成瀬 未春 on 2022/08/28.
+//
+
+public struct Fluit: Identifiable {
+    public let id: UUID
+    public let text: String
+
+    public init(id: UUID = UUID(), text: String) {
+        self.id = id
+        self.text = text
+    }
+}

--- a/Shared/Main/Source/Views/Home/HomeView.swift
+++ b/Shared/Main/Source/Views/Home/HomeView.swift
@@ -26,6 +26,9 @@ struct HomeView: View {
                 NavigationLink(destination: HideNavigationViewView()) {
                     Text("NavigationViewを隠す")
                 }
+                NavigationLink(destination: PassValueBetweenScreensView()) {
+                    Text("画面遷移時に値を渡す")
+                }
             }
         }
         .navigationTitle("100本ノック")

--- a/Shared/Main/Source/Views/PassValueBetweenScreens/PassValueBetweenScreensDetailView.swift
+++ b/Shared/Main/Source/Views/PassValueBetweenScreens/PassValueBetweenScreensDetailView.swift
@@ -1,0 +1,22 @@
+//
+//  PassValueBetweenScreensDetailView.swift
+//  SwiftUI100Knocks (iOS)
+//
+//  Created by 成瀬 未春 on 2022/08/28.
+//
+
+import SwiftUI
+
+struct PassValueBetweenScreensDetailView: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+    }
+}
+
+struct PassValueBetweenScreensDetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        PassValueBetweenScreensDetailView(text: "Apple")
+    }
+}

--- a/Shared/Main/Source/Views/PassValueBetweenScreens/PassValueBetweenScreensView.swift
+++ b/Shared/Main/Source/Views/PassValueBetweenScreens/PassValueBetweenScreensView.swift
@@ -5,11 +5,24 @@
 //  Created by 成瀬 未春 on 2022/08/28.
 //
 
+import Domain
 import SwiftUI
 
 struct PassValueBetweenScreensView: View {
+    private let fluits: [Fluit] = [
+        Fluit(text: "Apple"),
+        Fluit(text: "Banana"),
+        Fluit(text: "Orange"),
+        Fluit(text: "Grape"),
+        Fluit(text: "Peach"),
+    ]
+
     var body: some View {
-        Text("Hello, world!")
+        List {
+            ForEach(fluits) { fluit in
+                NavigationLink(fluit.text, destination: PassValueBetweenScreensDetailView(text: fluit.text))
+            }
+        }
     }
 }
 

--- a/Shared/Main/Source/Views/PassValueBetweenScreens/PassValueBetweenScreensView.swift
+++ b/Shared/Main/Source/Views/PassValueBetweenScreens/PassValueBetweenScreensView.swift
@@ -1,0 +1,20 @@
+//
+//  PassValueBetweenScreensView.swift
+//  SwiftUI100Knocks (iOS)
+//
+//  Created by 成瀬 未春 on 2022/08/28.
+//
+
+import SwiftUI
+
+struct PassValueBetweenScreensView: View {
+    var body: some View {
+        Text("Hello, world!")
+    }
+}
+
+struct PassValueBetweenScreensView_Previews: PreviewProvider {
+    static var previews: some View {
+        PassValueBetweenScreensView()
+    }
+}

--- a/SwiftUI100Knocks.xcodeproj/project.pbxproj
+++ b/SwiftUI100Knocks.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		462034D428B0E46D00540D3A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 462034AA28B0E46D00540D3A /* Assets.xcassets */; };
 		463F8A5128BB967E00EC146E /* PassValueBetweenScreensView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463F8A5028BB967E00EC146E /* PassValueBetweenScreensView.swift */; };
 		46CC7CCE28BBA27D0016A7A8 /* PassValueBetweenScreensDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CC7CCD28BBA27D0016A7A8 /* PassValueBetweenScreensDetailView.swift */; };
+		46CC7CD128BBA3D40016A7A8 /* Fluit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CC7CD028BBA3D40016A7A8 /* Fluit.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -99,6 +100,7 @@
 		462034C228B0E46D00540D3A /* Tests_iOSLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_iOSLaunchTests.swift; sourceTree = "<group>"; };
 		463F8A5028BB967E00EC146E /* PassValueBetweenScreensView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassValueBetweenScreensView.swift; sourceTree = "<group>"; };
 		46CC7CCD28BBA27D0016A7A8 /* PassValueBetweenScreensDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassValueBetweenScreensDetailView.swift; sourceTree = "<group>"; };
+		46CC7CD028BBA3D40016A7A8 /* Fluit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fluit.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -188,6 +190,7 @@
 		460572E828B535CE00C46366 /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				46CC7CCF28BBA3CB0016A7A8 /* Model */,
 				460572E928B535CE00C46366 /* Domain.h */,
 				460572EA28B535CE00C46366 /* Domain.docc */,
 			);
@@ -298,6 +301,14 @@
 				46CC7CCD28BBA27D0016A7A8 /* PassValueBetweenScreensDetailView.swift */,
 			);
 			path = PassValueBetweenScreens;
+			sourceTree = "<group>";
+		};
+		46CC7CCF28BBA3CB0016A7A8 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				46CC7CD028BBA3D40016A7A8 /* Fluit.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -520,6 +531,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				46CC7CD128BBA3D40016A7A8 /* Fluit.swift in Sources */,
 				460572EB28B535CE00C46366 /* Domain.docc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -799,6 +811,7 @@
 		462034D928B0E46D00540D3A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
@@ -828,6 +841,7 @@
 		462034DA28B0E46D00540D3A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;

--- a/SwiftUI100Knocks.xcodeproj/project.pbxproj
+++ b/SwiftUI100Knocks.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		462034D028B0E46D00540D3A /* SwiftUI100KnocksApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462034A828B0E46A00540D3A /* SwiftUI100KnocksApp.swift */; };
 		462034D228B0E46D00540D3A /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462034A928B0E46A00540D3A /* HomeView.swift */; };
 		462034D428B0E46D00540D3A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 462034AA28B0E46D00540D3A /* Assets.xcassets */; };
+		463F8A5128BB967E00EC146E /* PassValueBetweenScreensView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463F8A5028BB967E00EC146E /* PassValueBetweenScreensView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -95,6 +96,7 @@
 		462034BC28B0E46D00540D3A /* Tests iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Tests iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		462034C028B0E46D00540D3A /* Tests_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_iOS.swift; sourceTree = "<group>"; };
 		462034C228B0E46D00540D3A /* Tests_iOSLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_iOSLaunchTests.swift; sourceTree = "<group>"; };
+		463F8A5028BB967E00EC146E /* PassValueBetweenScreensView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassValueBetweenScreensView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -262,6 +264,7 @@
 				2821269C28B9BFDF00053CEF /* HideNavigationViewView */,
 				462034E928B0F09000540D3A /* Home */,
 				287D25C028B8FF330000A5B7 /* ImagesSideBySide */,
+				463F8A4F28BB964200EC146E /* PassValueBetweenScreens */,
 				2870F77A28B679EC00718060 /* ResizeImageAndClip */,
 				280B729C28B83A87002966AE /* ResizeImageToCircleWithBorder */,
 				2870F77728B665B400718060 /* ResizeImageToFit */,
@@ -284,6 +287,14 @@
 				462034A928B0E46A00540D3A /* HomeView.swift */,
 			);
 			path = Home;
+			sourceTree = "<group>";
+		};
+		463F8A4F28BB964200EC146E /* PassValueBetweenScreens */ = {
+			isa = PBXGroup;
+			children = (
+				463F8A5028BB967E00EC146E /* PassValueBetweenScreensView.swift */,
+			);
+			path = PassValueBetweenScreens;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -528,6 +539,7 @@
 				287D25C228B8FF7F0000A5B7 /* ImagesSideBySideView.swift in Sources */,
 				287D25BF28B8FEA60000A5B7 /* Assets-Constants.swift in Sources */,
 				2821269E28B9BFF900053CEF /* HideNavigationViewView.swift in Sources */,
+				463F8A5128BB967E00EC146E /* PassValueBetweenScreensView.swift in Sources */,
 				280B729E28B83AAD002966AE /* ResizeImageToCircleWithBorderView.swift in Sources */,
 				287D25BE28B8FEA60000A5B7 /* L10n-Constants.swift in Sources */,
 				2870F77928B665D100718060 /* ResizeImageToFitView.swift in Sources */,

--- a/SwiftUI100Knocks.xcodeproj/project.pbxproj
+++ b/SwiftUI100Knocks.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		462034D228B0E46D00540D3A /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462034A928B0E46A00540D3A /* HomeView.swift */; };
 		462034D428B0E46D00540D3A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 462034AA28B0E46D00540D3A /* Assets.xcassets */; };
 		463F8A5128BB967E00EC146E /* PassValueBetweenScreensView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463F8A5028BB967E00EC146E /* PassValueBetweenScreensView.swift */; };
+		46CC7CCE28BBA27D0016A7A8 /* PassValueBetweenScreensDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CC7CCD28BBA27D0016A7A8 /* PassValueBetweenScreensDetailView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -97,6 +98,7 @@
 		462034C028B0E46D00540D3A /* Tests_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_iOS.swift; sourceTree = "<group>"; };
 		462034C228B0E46D00540D3A /* Tests_iOSLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_iOSLaunchTests.swift; sourceTree = "<group>"; };
 		463F8A5028BB967E00EC146E /* PassValueBetweenScreensView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassValueBetweenScreensView.swift; sourceTree = "<group>"; };
+		46CC7CCD28BBA27D0016A7A8 /* PassValueBetweenScreensDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassValueBetweenScreensDetailView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -293,6 +295,7 @@
 			isa = PBXGroup;
 			children = (
 				463F8A5028BB967E00EC146E /* PassValueBetweenScreensView.swift */,
+				46CC7CCD28BBA27D0016A7A8 /* PassValueBetweenScreensDetailView.swift */,
 			);
 			path = PassValueBetweenScreens;
 			sourceTree = "<group>";
@@ -536,6 +539,7 @@
 				462034D228B0E46D00540D3A /* HomeView.swift in Sources */,
 				462034D028B0E46D00540D3A /* SwiftUI100KnocksApp.swift in Sources */,
 				2870F77C28B67A0C00718060 /* ResizeImageAndClipView.swift in Sources */,
+				46CC7CCE28BBA27D0016A7A8 /* PassValueBetweenScreensDetailView.swift in Sources */,
 				287D25C228B8FF7F0000A5B7 /* ImagesSideBySideView.swift in Sources */,
 				287D25BF28B8FEA60000A5B7 /* Assets-Constants.swift in Sources */,
 				2821269E28B9BFF900053CEF /* HideNavigationViewView.swift in Sources */,


### PR DESCRIPTION
## 変更の概要

- Closes #16 

## なぜこの変更をするのか

- 上記課題を達成するため。

## やったこと

- [x] `Fluit` モデルの作成
- [x] 一覧画面の作成
- [x] 詳細画面の作成
- [x] 一覧画面から詳細画面へ値を渡して画面遷移する処理 

## 変更内容

- UIの変更ならスクリーンショット

| Home | 一覧画面 | 詳細画面 |
| --- | --- | --- |
| ![home](https://user-images.githubusercontent.com/35392604/187076623-3e4e2d1f-ac43-4e4b-b5b2-5f58bc6a4bc2.png) | ![list](https://user-images.githubusercontent.com/35392604/187076625-7d4d0536-3807-4cb2-882e-8f20136cb7d8.png) | ![detail](https://user-images.githubusercontent.com/35392604/187076622-6d981c3d-e3ac-46e2-ad48-441c7bfe87cf.png) |

## 影響範囲

- なし

## どうやるのか

- 再現手順
    - アプリを実行する。

## 課題

- なし

## 備考

- なし
