### PR TITLE
TabViewを使って画面を切り替える #25

### DIFF
--- a/Shared/Main/Source/Views/Home/HomeView.swift
+++ b/Shared/Main/Source/Views/Home/HomeView.swift
@@ -32,6 +32,9 @@ struct HomeView: View {
                 NavigationLink(destination: ShowPickerView()) {
                     Text("Pickerを表示する")
                 }
+                NavigationLink(destination: TripleTabView()) {
+                    Text("TabViewを使って画面を切り替える")
+                }
             }
         }
         .navigationTitle("100本ノック")

--- a/Shared/Main/Source/Views/Tab/TripleTabView.swift
+++ b/Shared/Main/Source/Views/Tab/TripleTabView.swift
@@ -13,6 +13,7 @@ struct TripleTabView: View {
     var body: some View {
         TabView {
             TabFirstView()
+                .badge(2)
                 .tabItem {
                     Label("First", systemImage: "tray.and.arrow.down.fill")
                 }
@@ -23,6 +24,7 @@ struct TripleTabView: View {
                 }
 
             TabThirdView()
+                .badge("あいう")
                 .tabItem {
                     Label("Third", systemImage: "person.crop.circle.fill")
                 }

--- a/Shared/Main/Source/Views/Tab/TripleTabView.swift
+++ b/Shared/Main/Source/Views/Tab/TripleTabView.swift
@@ -11,7 +11,22 @@ import SwiftUI
 
 struct TripleTabView: View {
     var body: some View {
-        Text("Hello, world!")
+        TabView {
+            TabFirstView()
+                .tabItem {
+                    Label("First", systemImage: "tray.and.arrow.down.fill")
+                }
+
+            TabSecondView()
+                .tabItem {
+                    Label("Second", systemImage: "tray.and.arrow.up.fill")
+                }
+
+            TabThirdView()
+                .tabItem {
+                    Label("Third", systemImage: "person.crop.circle.fill")
+                }
+        }
     }
 }
 

--- a/Shared/Main/Source/Views/Tab/TripleTabView.swift
+++ b/Shared/Main/Source/Views/Tab/TripleTabView.swift
@@ -1,0 +1,22 @@
+//
+//  TripleTabView.swift
+//  SwiftUI100Knocks (iOS)
+//
+//  Created by 成瀬 未春 on 2022/11/15.
+//
+
+// https://developer.apple.com/documentation/swiftui/tabview
+
+import SwiftUI
+
+struct TripleTabView: View {
+    var body: some View {
+        Text("Hello, world!")
+    }
+}
+
+struct TripleTabView_Previews: PreviewProvider {
+    static var previews: some View {
+        TripleTabView()
+    }
+}

--- a/Shared/Main/Source/Views/Tab/Views/TabFirstView.swift
+++ b/Shared/Main/Source/Views/Tab/Views/TabFirstView.swift
@@ -1,0 +1,24 @@
+//
+//  TabFirstView.swift
+//  SwiftUI100Knocks (iOS)
+//
+//  Created by 成瀬 未春 on 2022/11/15.
+//
+
+import SwiftUI
+
+struct TabFirstView: View {
+    var body: some View {
+        ZStack {
+            Color.blue
+            Text("1")
+                .foregroundColor(.white)
+        }
+    }
+}
+
+struct TabFirstView_Previews: PreviewProvider {
+    static var previews: some View {
+        TabFirstView()
+    }
+}

--- a/Shared/Main/Source/Views/Tab/Views/TabSecondView.swift
+++ b/Shared/Main/Source/Views/Tab/Views/TabSecondView.swift
@@ -1,0 +1,24 @@
+//
+//  TabSecondView.swift
+//  SwiftUI100Knocks (iOS)
+//
+//  Created by 成瀬 未春 on 2022/11/15.
+//
+
+import SwiftUI
+
+struct TabSecondView: View {
+    var body: some View {
+        ZStack {
+            Color.yellow
+
+            Text("2")
+        }
+    }
+}
+
+struct TabSecondView_Previews: PreviewProvider {
+    static var previews: some View {
+        TabSecondView()
+    }
+}

--- a/Shared/Main/Source/Views/Tab/Views/TabThirdView.swift
+++ b/Shared/Main/Source/Views/Tab/Views/TabThirdView.swift
@@ -1,0 +1,25 @@
+//
+//  TabThirdView.swift
+//  SwiftUI100Knocks (iOS)
+//
+//  Created by 成瀬 未春 on 2022/11/15.
+//
+
+import SwiftUI
+
+struct TabThirdView: View {
+    var body: some View {
+        ZStack {
+            Color.red
+
+            Text("3")
+                .foregroundColor(.white)
+        }
+    }
+}
+
+struct TabThirdView_Previews: PreviewProvider {
+    static var previews: some View {
+        TabThirdView()
+    }
+}

--- a/SwiftUI100Knocks.xcodeproj/project.pbxproj
+++ b/SwiftUI100Knocks.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		460572FC28B535CE00C46366 /* Domain.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 460572E728B535CE00C46366 /* Domain.framework */; };
 		460572FE28B535CE00C46366 /* Domain.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 460572E728B535CE00C46366 /* Domain.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4605731D28B5603700C46366 /* SDWebImageSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 4605731C28B5603700C46366 /* SDWebImageSwiftUI */; };
+		460B4E8F2923BB5E00B47C4F /* TripleTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460B4E8E2923BB5E00B47C4F /* TripleTabView.swift */; };
 		462034C128B0E46D00540D3A /* Tests_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462034C028B0E46D00540D3A /* Tests_iOS.swift */; };
 		462034C328B0E46D00540D3A /* Tests_iOSLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462034C228B0E46D00540D3A /* Tests_iOSLaunchTests.swift */; };
 		462034D028B0E46D00540D3A /* SwiftUI100KnocksApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462034A828B0E46A00540D3A /* SwiftUI100KnocksApp.swift */; };
@@ -98,6 +99,7 @@
 		460572EA28B535CE00C46366 /* Domain.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = Domain.docc; sourceTree = "<group>"; };
 		460572F028B535CE00C46366 /* DomainTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DomainTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		460572F728B535CE00C46366 /* DomainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainTests.swift; sourceTree = "<group>"; };
+		460B4E8E2923BB5E00B47C4F /* TripleTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripleTabView.swift; sourceTree = "<group>"; };
 		462034A828B0E46A00540D3A /* SwiftUI100KnocksApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUI100KnocksApp.swift; sourceTree = "<group>"; };
 		462034A928B0E46A00540D3A /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		462034AA28B0E46D00540D3A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -220,6 +222,14 @@
 			path = DomainTests;
 			sourceTree = "<group>";
 		};
+		460B4E8D2923BB3D00B47C4F /* Tab */ = {
+			isa = PBXGroup;
+			children = (
+				460B4E8E2923BB5E00B47C4F /* TripleTabView.swift */,
+			);
+			path = Tab;
+			sourceTree = "<group>";
+		};
 		462034A228B0E46A00540D3A = {
 			isa = PBXGroup;
 			children = (
@@ -289,6 +299,7 @@
 				280B729C28B83A87002966AE /* ResizeImageToCircleWithBorder */,
 				2870F77728B665B400718060 /* ResizeImageToFit */,
 				46CC7CD228BBA87B0016A7A8 /* ShowPicker */,
+				460B4E8D2923BB3D00B47C4F /* Tab */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -603,6 +614,7 @@
 				46C82B5328BC3BA7001AFF45 /* ShowInlinePickerView.swift in Sources */,
 				46CC7CD428BBA8870016A7A8 /* ShowPickerView.swift in Sources */,
 				46C82B4B28BC3A07001AFF45 /* ShowAutomaticPickerView.swift in Sources */,
+				460B4E8F2923BB5E00B47C4F /* TripleTabView.swift in Sources */,
 				2821269E28B9BFF900053CEF /* HideNavigationViewView.swift in Sources */,
 				46C82B4D28BC3A49001AFF45 /* ShowWheelPickerView.swift in Sources */,
 				463F8A5128BB967E00EC146E /* PassValueBetweenScreensView.swift in Sources */,

--- a/SwiftUI100Knocks.xcodeproj/project.pbxproj
+++ b/SwiftUI100Knocks.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 		460572FE28B535CE00C46366 /* Domain.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 460572E728B535CE00C46366 /* Domain.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4605731D28B5603700C46366 /* SDWebImageSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 4605731C28B5603700C46366 /* SDWebImageSwiftUI */; };
 		460B4E8F2923BB5E00B47C4F /* TripleTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460B4E8E2923BB5E00B47C4F /* TripleTabView.swift */; };
+		460B4E922923BD0200B47C4F /* TabFirstView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460B4E912923BD0200B47C4F /* TabFirstView.swift */; };
+		460B4E942923BDC600B47C4F /* TabSecondView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460B4E932923BDC600B47C4F /* TabSecondView.swift */; };
+		460B4E962923BDCE00B47C4F /* TabThirdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460B4E952923BDCE00B47C4F /* TabThirdView.swift */; };
 		462034C128B0E46D00540D3A /* Tests_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462034C028B0E46D00540D3A /* Tests_iOS.swift */; };
 		462034C328B0E46D00540D3A /* Tests_iOSLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462034C228B0E46D00540D3A /* Tests_iOSLaunchTests.swift */; };
 		462034D028B0E46D00540D3A /* SwiftUI100KnocksApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462034A828B0E46A00540D3A /* SwiftUI100KnocksApp.swift */; };
@@ -100,6 +103,9 @@
 		460572F028B535CE00C46366 /* DomainTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DomainTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		460572F728B535CE00C46366 /* DomainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainTests.swift; sourceTree = "<group>"; };
 		460B4E8E2923BB5E00B47C4F /* TripleTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripleTabView.swift; sourceTree = "<group>"; };
+		460B4E912923BD0200B47C4F /* TabFirstView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabFirstView.swift; sourceTree = "<group>"; };
+		460B4E932923BDC600B47C4F /* TabSecondView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSecondView.swift; sourceTree = "<group>"; };
+		460B4E952923BDCE00B47C4F /* TabThirdView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabThirdView.swift; sourceTree = "<group>"; };
 		462034A828B0E46A00540D3A /* SwiftUI100KnocksApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUI100KnocksApp.swift; sourceTree = "<group>"; };
 		462034A928B0E46A00540D3A /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		462034AA28B0E46D00540D3A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -225,9 +231,20 @@
 		460B4E8D2923BB3D00B47C4F /* Tab */ = {
 			isa = PBXGroup;
 			children = (
+				460B4E902923BCEE00B47C4F /* Views */,
 				460B4E8E2923BB5E00B47C4F /* TripleTabView.swift */,
 			);
 			path = Tab;
+			sourceTree = "<group>";
+		};
+		460B4E902923BCEE00B47C4F /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				460B4E912923BD0200B47C4F /* TabFirstView.swift */,
+				460B4E932923BDC600B47C4F /* TabSecondView.swift */,
+				460B4E952923BDCE00B47C4F /* TabThirdView.swift */,
+			);
+			path = Views;
 			sourceTree = "<group>";
 		};
 		462034A228B0E46A00540D3A = {
@@ -612,12 +629,15 @@
 				287D25C228B8FF7F0000A5B7 /* ImagesSideBySideView.swift in Sources */,
 				287D25BF28B8FEA60000A5B7 /* Assets-Constants.swift in Sources */,
 				46C82B5328BC3BA7001AFF45 /* ShowInlinePickerView.swift in Sources */,
+				460B4E922923BD0200B47C4F /* TabFirstView.swift in Sources */,
+				460B4E942923BDC600B47C4F /* TabSecondView.swift in Sources */,
 				46CC7CD428BBA8870016A7A8 /* ShowPickerView.swift in Sources */,
 				46C82B4B28BC3A07001AFF45 /* ShowAutomaticPickerView.swift in Sources */,
 				460B4E8F2923BB5E00B47C4F /* TripleTabView.swift in Sources */,
 				2821269E28B9BFF900053CEF /* HideNavigationViewView.swift in Sources */,
 				46C82B4D28BC3A49001AFF45 /* ShowWheelPickerView.swift in Sources */,
 				463F8A5128BB967E00EC146E /* PassValueBetweenScreensView.swift in Sources */,
+				460B4E962923BDCE00B47C4F /* TabThirdView.swift in Sources */,
 				280B729E28B83AAD002966AE /* ResizeImageToCircleWithBorderView.swift in Sources */,
 				46C82B4F28BC3AE4001AFF45 /* ShowMenuPickerView.swift in Sources */,
 				287D25BE28B8FEA60000A5B7 /* L10n-Constants.swift in Sources */,


### PR DESCRIPTION
## 変更の概要

- closes #25 

## なぜこの変更をするのか

- TabView を使ってみるため。

## やったこと

- [x] TabViewの追加

おまけ

- [x] 各タブの最初の画面の背景色の設定を ZStack を使って行った。
- [x] タブに badge を使ってみた。数字だけじゃなくて、文字列も設定できる。

## 変更内容

- UIの変更ならスクリーンショット

| ホーム画面 | タブ１ | タブ２ | タブ３ |
| --- | --- | --- | --- |
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-15 at 21 52 58](https://user-images.githubusercontent.com/35392604/201924429-e0dc0698-d7e7-4c3b-86f1-1a596cebf013.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-15 at 21 53 01](https://user-images.githubusercontent.com/35392604/201924438-20104a59-3da1-4d19-808c-cac69f8cefb3.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-15 at 21 53 03](https://user-images.githubusercontent.com/35392604/201924443-357ab11b-8ec6-4ed1-8a11-33a6856b12bf.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-15 at 21 53 05](https://user-images.githubusercontent.com/35392604/201924445-97c2a01a-101d-4a67-9128-7598c502b72b.png) |

- APIの変更ならリクエストとレスポンス

## 影響範囲

- ユーザに影響すること
- メンバーに影響すること
- システムに影響すること

## どうやるのか

- 使い方
- 再現手順

## 課題

- 悩んでいること
- とくにレビューしてほしいところ

## 備考

- その他に伝えたいこと
