### PR TITLE
いろんなボタンを使ってみる

### DIFF
--- a/Shared/Main/Source/Views/CheckButtons/CheckButtonsView.swift
+++ b/Shared/Main/Source/Views/CheckButtons/CheckButtonsView.swift
@@ -16,8 +16,11 @@ struct CheckButtonsView: View {
             NavigationLink("Full Width Buttons") {
                 FullWidthButtonsView()
             }
+            NavigationLink("NG Full Width Buttons") {
+                NGFullWidthButtonsView()
+            }
         }
-        .navigationTitle("いろいろなボタンを使ってみる")
+        .navigationTitle("いろいろなボタン")
     }
 }
 

--- a/Shared/Main/Source/Views/CheckButtons/CheckButtonsView.swift
+++ b/Shared/Main/Source/Views/CheckButtons/CheckButtonsView.swift
@@ -1,0 +1,30 @@
+//
+//  CheckButtonsView.swift
+//  SwiftUI100Knocks (iOS)
+//
+//  Created by 成瀬 未春 on 2022/11/15.
+//
+
+import SwiftUI
+
+struct CheckButtonsView: View {
+    var body: some View {
+        List {
+            NavigationLink("Natural Width Buttons") {
+                NaturalWidthButtonsView()
+            }
+            NavigationLink("Full Width Buttons") {
+                FullWidthButtonsView()
+            }
+        }
+        .navigationTitle("いろいろなボタンを使ってみる")
+    }
+}
+
+struct CheckButtonsView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            CheckButtonsView()
+        }
+    }
+}

--- a/Shared/Main/Source/Views/CheckButtons/Views/FullWidthButtonsView.swift
+++ b/Shared/Main/Source/Views/CheckButtons/Views/FullWidthButtonsView.swift
@@ -1,0 +1,62 @@
+//
+//  FullWidthButtonsView.swift
+//  SwiftUI100Knocks (iOS)
+//
+//  Created by 成瀬 未春 on 2022/11/16.
+//
+
+import SwiftUI
+
+struct FullWidthButtonsView: View {
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 32) {
+                Button {
+                    // action
+                } label: {
+                    Text("borderedProminent")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                Button {
+                    // action
+                } label: {
+                    Text("bordered")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+                Button {
+                    // action
+                } label: {
+                    Text("borderless")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderless)
+                Button {
+                    // action
+                } label: {
+                    Text("plain")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.plain)
+                Button {
+                    // action
+                } label: {
+                    Text("automatic")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.automatic)
+            }
+            .padding()
+        }
+        .navigationTitle("Full Width Buttons")
+    }
+}
+
+struct FullWidthButtonsView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            FullWidthButtonsView()
+        }
+    }
+}

--- a/Shared/Main/Source/Views/CheckButtons/Views/NGFullWidthButtonsView.swift
+++ b/Shared/Main/Source/Views/CheckButtons/Views/NGFullWidthButtonsView.swift
@@ -1,0 +1,68 @@
+//
+//  NGFullWidthButtonsView.swift
+//  SwiftUI100Knocks (iOS)
+//
+//  Created by 成瀬 未春 on 2022/11/16.
+//
+
+import SwiftUI
+
+struct NGFullWidthButtonsView: View {
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 32) {
+                ZStack {
+                    Rectangle()
+                        .fill(Color.accentColor)
+                        .cornerRadius(10)
+
+                    Text("Button に対して `.frame(maxWidth: .infinity)` をつけても、ボタンの幅は思ったように広がりません。\nButton 内の Text 等に対して、frame をつける必要があります。\n正しくは、 Full Width Buttons のコードを確認してください。")
+                        .foregroundColor(.white)
+                        .padding()
+                }
+
+                VStack(spacing: 32) {
+                    Button("borderedProminent") {
+                        // action
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .frame(maxWidth: .infinity)
+
+                    Button("bordered") {
+                        // action
+                    }
+                    .buttonStyle(.bordered)
+                    .frame(maxWidth: .infinity)
+
+                    Button("borderless") {
+                        // action
+                    }
+                    .buttonStyle(.borderless)
+                    .frame(maxWidth: .infinity)
+
+                    Button("plain") {
+                        // action
+                    }
+                    .buttonStyle(.plain)
+                    .frame(maxWidth: .infinity)
+
+                    Button("automatic") {
+                        // action
+                    }
+                    .buttonStyle(.automatic)
+                    .frame(maxWidth: .infinity)
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("NG Full Width Buttons")
+    }
+}
+
+struct NGFullWidthButtonsView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            NGFullWidthButtonsView()
+        }
+    }
+}

--- a/Shared/Main/Source/Views/CheckButtons/Views/NaturalWidthButtonsView.swift
+++ b/Shared/Main/Source/Views/CheckButtons/Views/NaturalWidthButtonsView.swift
@@ -1,0 +1,51 @@
+//
+//  NaturalWidthButtonsView.swift
+//  SwiftUI100Knocks (iOS)
+//
+//  Created by 成瀬 未春 on 2022/11/16.
+//
+
+import SwiftUI
+
+struct NaturalWidthButtonsView: View {
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 32) {
+                Button("borderedProminent") {
+                    // action
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button("bordered") {
+                    // action
+                }
+                .buttonStyle(.bordered)
+
+                Button("borderless") {
+                    // action
+                }
+                .buttonStyle(.borderless)
+
+                Button("plain") {
+                    // action
+                }
+                .buttonStyle(.plain)
+
+                Button("automatic") {
+                    // action
+                }
+                .buttonStyle(.automatic)
+            }
+            .padding()
+        }
+        .navigationTitle("Natural Width Buttons")
+    }
+}
+
+struct NaturalWidthButtonsView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            NaturalWidthButtonsView()
+        }
+    }
+}

--- a/Shared/Main/Source/Views/Home/HomeView.swift
+++ b/Shared/Main/Source/Views/Home/HomeView.swift
@@ -38,6 +38,9 @@ struct HomeView: View {
                 NavigationLink(destination: TapThenChangeTextView()) {
                     Text("Buttonが押されたら文字を変える")
                 }
+                NavigationLink(destination: CheckButtonsView()) {
+                    Text("いろいろなButtonを使ってみる")
+                }
             }
         }
         .navigationTitle("100本ノック")

--- a/SwiftUI100Knocks.xcodeproj/project.pbxproj
+++ b/SwiftUI100Knocks.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		460B4E942923BDC600B47C4F /* TabSecondView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460B4E932923BDC600B47C4F /* TabSecondView.swift */; };
 		460B4E962923BDCE00B47C4F /* TabThirdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460B4E952923BDCE00B47C4F /* TabThirdView.swift */; };
 		460B4E992923C47A00B47C4F /* TapThenChangeTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460B4E982923C47A00B47C4F /* TapThenChangeTextView.swift */; };
+		460B4E9C2923CA2300B47C4F /* CheckButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460B4E9B2923CA2300B47C4F /* CheckButtonsView.swift */; };
 		462034C128B0E46D00540D3A /* Tests_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462034C028B0E46D00540D3A /* Tests_iOS.swift */; };
 		462034C328B0E46D00540D3A /* Tests_iOSLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462034C228B0E46D00540D3A /* Tests_iOSLaunchTests.swift */; };
 		462034D028B0E46D00540D3A /* SwiftUI100KnocksApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462034A828B0E46A00540D3A /* SwiftUI100KnocksApp.swift */; };
@@ -38,6 +39,8 @@
 		46C82B4F28BC3AE4001AFF45 /* ShowMenuPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C82B4E28BC3AE4001AFF45 /* ShowMenuPickerView.swift */; };
 		46C82B5128BC3B7A001AFF45 /* ShowSegmentedPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C82B5028BC3B7A001AFF45 /* ShowSegmentedPickerView.swift */; };
 		46C82B5328BC3BA7001AFF45 /* ShowInlinePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C82B5228BC3BA7001AFF45 /* ShowInlinePickerView.swift */; };
+		46C83FB429246EF300B6BD4D /* FullWidthButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C83FB329246EF300B6BD4D /* FullWidthButtonsView.swift */; };
+		46C83FB629246F0000B6BD4D /* NaturalWidthButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C83FB529246F0000B6BD4D /* NaturalWidthButtonsView.swift */; };
 		46CC7CCE28BBA27D0016A7A8 /* PassValueBetweenScreensDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CC7CCD28BBA27D0016A7A8 /* PassValueBetweenScreensDetailView.swift */; };
 		46CC7CD128BBA3D40016A7A8 /* Fluit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CC7CD028BBA3D40016A7A8 /* Fluit.swift */; };
 		46CC7CD428BBA8870016A7A8 /* ShowPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CC7CD328BBA8870016A7A8 /* ShowPickerView.swift */; };
@@ -108,6 +111,7 @@
 		460B4E932923BDC600B47C4F /* TabSecondView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabSecondView.swift; sourceTree = "<group>"; };
 		460B4E952923BDCE00B47C4F /* TabThirdView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabThirdView.swift; sourceTree = "<group>"; };
 		460B4E982923C47A00B47C4F /* TapThenChangeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapThenChangeTextView.swift; sourceTree = "<group>"; };
+		460B4E9B2923CA2300B47C4F /* CheckButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckButtonsView.swift; sourceTree = "<group>"; };
 		462034A828B0E46A00540D3A /* SwiftUI100KnocksApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUI100KnocksApp.swift; sourceTree = "<group>"; };
 		462034A928B0E46A00540D3A /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		462034AA28B0E46D00540D3A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -121,6 +125,8 @@
 		46C82B4E28BC3AE4001AFF45 /* ShowMenuPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowMenuPickerView.swift; sourceTree = "<group>"; };
 		46C82B5028BC3B7A001AFF45 /* ShowSegmentedPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowSegmentedPickerView.swift; sourceTree = "<group>"; };
 		46C82B5228BC3BA7001AFF45 /* ShowInlinePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowInlinePickerView.swift; sourceTree = "<group>"; };
+		46C83FB329246EF300B6BD4D /* FullWidthButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullWidthButtonsView.swift; sourceTree = "<group>"; };
+		46C83FB529246F0000B6BD4D /* NaturalWidthButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaturalWidthButtonsView.swift; sourceTree = "<group>"; };
 		46CC7CCD28BBA27D0016A7A8 /* PassValueBetweenScreensDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassValueBetweenScreensDetailView.swift; sourceTree = "<group>"; };
 		46CC7CD028BBA3D40016A7A8 /* Fluit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fluit.swift; sourceTree = "<group>"; };
 		46CC7CD328BBA8870016A7A8 /* ShowPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowPickerView.swift; sourceTree = "<group>"; };
@@ -257,6 +263,15 @@
 			path = TapThenChangeText;
 			sourceTree = "<group>";
 		};
+		460B4E9A2923CA1100B47C4F /* CheckButtons */ = {
+			isa = PBXGroup;
+			children = (
+				460B4E9B2923CA2300B47C4F /* CheckButtonsView.swift */,
+				46C83FB72924701600B6BD4D /* Views */,
+			);
+			path = CheckButtons;
+			sourceTree = "<group>";
+		};
 		462034A228B0E46A00540D3A = {
 			isa = PBXGroup;
 			children = (
@@ -318,6 +333,7 @@
 		462034E728B0F03500540D3A /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				460B4E9A2923CA1100B47C4F /* CheckButtons */,
 				2821269C28B9BFDF00053CEF /* HideNavigationViewView */,
 				462034E928B0F09000540D3A /* Home */,
 				287D25C028B8FF330000A5B7 /* ImagesSideBySide */,
@@ -366,6 +382,15 @@
 				46C82B4E28BC3AE4001AFF45 /* ShowMenuPickerView.swift */,
 				46C82B5028BC3B7A001AFF45 /* ShowSegmentedPickerView.swift */,
 				46C82B4C28BC3A49001AFF45 /* ShowWheelPickerView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
+		46C83FB72924701600B6BD4D /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				46C83FB329246EF300B6BD4D /* FullWidthButtonsView.swift */,
+				46C83FB529246F0000B6BD4D /* NaturalWidthButtonsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -635,11 +660,13 @@
 			files = (
 				462034D228B0E46D00540D3A /* HomeView.swift in Sources */,
 				462034D028B0E46D00540D3A /* SwiftUI100KnocksApp.swift in Sources */,
+				46C83FB429246EF300B6BD4D /* FullWidthButtonsView.swift in Sources */,
 				2870F77C28B67A0C00718060 /* ResizeImageAndClipView.swift in Sources */,
 				46CC7CCE28BBA27D0016A7A8 /* PassValueBetweenScreensDetailView.swift in Sources */,
 				287D25C228B8FF7F0000A5B7 /* ImagesSideBySideView.swift in Sources */,
 				287D25BF28B8FEA60000A5B7 /* Assets-Constants.swift in Sources */,
 				460B4E992923C47A00B47C4F /* TapThenChangeTextView.swift in Sources */,
+				460B4E9C2923CA2300B47C4F /* CheckButtonsView.swift in Sources */,
 				46C82B5328BC3BA7001AFF45 /* ShowInlinePickerView.swift in Sources */,
 				460B4E922923BD0200B47C4F /* TabFirstView.swift in Sources */,
 				460B4E942923BDC600B47C4F /* TabSecondView.swift in Sources */,
@@ -655,6 +682,7 @@
 				287D25BE28B8FEA60000A5B7 /* L10n-Constants.swift in Sources */,
 				46C82B5128BC3B7A001AFF45 /* ShowSegmentedPickerView.swift in Sources */,
 				2870F77928B665D100718060 /* ResizeImageToFitView.swift in Sources */,
+				46C83FB629246F0000B6BD4D /* NaturalWidthButtonsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftUI100Knocks.xcodeproj/project.pbxproj
+++ b/SwiftUI100Knocks.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		46C82B5328BC3BA7001AFF45 /* ShowInlinePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C82B5228BC3BA7001AFF45 /* ShowInlinePickerView.swift */; };
 		46C83FB429246EF300B6BD4D /* FullWidthButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C83FB329246EF300B6BD4D /* FullWidthButtonsView.swift */; };
 		46C83FB629246F0000B6BD4D /* NaturalWidthButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C83FB529246F0000B6BD4D /* NaturalWidthButtonsView.swift */; };
+		46C83FB92924726B00B6BD4D /* NGFullWidthButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C83FB82924726B00B6BD4D /* NGFullWidthButtonsView.swift */; };
 		46CC7CCE28BBA27D0016A7A8 /* PassValueBetweenScreensDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CC7CCD28BBA27D0016A7A8 /* PassValueBetweenScreensDetailView.swift */; };
 		46CC7CD128BBA3D40016A7A8 /* Fluit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CC7CD028BBA3D40016A7A8 /* Fluit.swift */; };
 		46CC7CD428BBA8870016A7A8 /* ShowPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CC7CD328BBA8870016A7A8 /* ShowPickerView.swift */; };
@@ -127,6 +128,7 @@
 		46C82B5228BC3BA7001AFF45 /* ShowInlinePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowInlinePickerView.swift; sourceTree = "<group>"; };
 		46C83FB329246EF300B6BD4D /* FullWidthButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullWidthButtonsView.swift; sourceTree = "<group>"; };
 		46C83FB529246F0000B6BD4D /* NaturalWidthButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaturalWidthButtonsView.swift; sourceTree = "<group>"; };
+		46C83FB82924726B00B6BD4D /* NGFullWidthButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NGFullWidthButtonsView.swift; sourceTree = "<group>"; };
 		46CC7CCD28BBA27D0016A7A8 /* PassValueBetweenScreensDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassValueBetweenScreensDetailView.swift; sourceTree = "<group>"; };
 		46CC7CD028BBA3D40016A7A8 /* Fluit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fluit.swift; sourceTree = "<group>"; };
 		46CC7CD328BBA8870016A7A8 /* ShowPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowPickerView.swift; sourceTree = "<group>"; };
@@ -391,6 +393,7 @@
 			children = (
 				46C83FB329246EF300B6BD4D /* FullWidthButtonsView.swift */,
 				46C83FB529246F0000B6BD4D /* NaturalWidthButtonsView.swift */,
+				46C83FB82924726B00B6BD4D /* NGFullWidthButtonsView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -677,6 +680,7 @@
 				46C82B4D28BC3A49001AFF45 /* ShowWheelPickerView.swift in Sources */,
 				463F8A5128BB967E00EC146E /* PassValueBetweenScreensView.swift in Sources */,
 				460B4E962923BDCE00B47C4F /* TabThirdView.swift in Sources */,
+				46C83FB92924726B00B6BD4D /* NGFullWidthButtonsView.swift in Sources */,
 				280B729E28B83AAD002966AE /* ResizeImageToCircleWithBorderView.swift in Sources */,
 				46C82B4F28BC3AE4001AFF45 /* ShowMenuPickerView.swift in Sources */,
 				287D25BE28B8FEA60000A5B7 /* L10n-Constants.swift in Sources */,


### PR DESCRIPTION
## 変更の概要

- closes #49 

## なぜこの変更をするのか

- 標準機能で装備されているボタンについて知る。
- フルワイドなボタンにするために必要なコードを知る。

## やったこと

- [x] いろいろなボタンのビューを作成。
- [x] NGコードをあえて追加。 

## 変更内容

- UIの変更ならスクリーンショット

| ホーム画面 | いろいろなボタンのリスト | 自然な幅のボタン | フルワイドなボタン | フルワイドにできないNGコードのボタン |
| --- | --- | --- | --- | --- |
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-16 at 10 54 56](https://user-images.githubusercontent.com/35392604/202064344-c2f11df5-1576-4e91-b103-9de12a03aa5f.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-16 at 10 54 59](https://user-images.githubusercontent.com/35392604/202064355-ef94a945-bed1-4c0c-8871-d3b642ccc655.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-16 at 10 55 01](https://user-images.githubusercontent.com/35392604/202064363-c5a1fd48-bb61-4eb1-aba3-cdf46298c824.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-16 at 10 55 07](https://user-images.githubusercontent.com/35392604/202064369-0f15ad52-8db9-4698-bd27-ecbea6f2b919.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-16 at 10 55 12](https://user-images.githubusercontent.com/35392604/202064373-3632ea9e-4951-494a-a65d-b81149031bd5.png) |

- APIの変更ならリクエストとレスポンス

## 影響範囲

- ユーザに影響すること
- メンバーに影響すること
- システムに影響すること

## どうやるのか

- 使い方
- 再現手順

## 課題

- 悩んでいること
- とくにレビューしてほしいところ

## 備考

- その他に伝えたいこと
