### PR TITLE
アラートを表示する

### DIFF
--- a/Shared/Main/Source/Views/Alert/ShowAlertView.swift
+++ b/Shared/Main/Source/Views/Alert/ShowAlertView.swift
@@ -1,0 +1,41 @@
+//
+//  ShowAlertView.swift
+//  SwiftUI100Knocks (iOS)
+//
+//  Created by 成瀬 未春 on 2022/11/21.
+//
+
+// Alert iOS 13.0 - 16.1 Deprecated
+// Use a View modifier like alert(_:isPresented:presenting:actions:message:) instead.
+// https://developer.apple.com/documentation/swiftui/view/alert(_:ispresented:presenting:actions:message:)-8584l
+
+import SwiftUI
+
+struct ShowAlertView: View {
+    @State private var didError: Bool = false
+
+    var body: some View {
+        Button("Tap Me") {
+            didError = true
+        }
+        .alert(
+            "タイトル",
+            isPresented: $didError
+        ) {
+            Button("ボタンその１", role: .cancel) {
+                print("ボタンその１がタップされました。")
+            }
+            Button("ボタンその２", role: .destructive) {
+                print("ボタンその２がタップされました。")
+            }
+        } message: {
+            Text("メッセージ")
+        }
+    }
+}
+
+struct ShowAlertView_Previews: PreviewProvider {
+    static var previews: some View {
+        ShowAlertView()
+    }
+}

--- a/Shared/Main/Source/Views/Home/HomeView.swift
+++ b/Shared/Main/Source/Views/Home/HomeView.swift
@@ -23,6 +23,7 @@ struct HomeView: View {
         case tripleTab
         case tapThenChangeText
         case checkButtons
+        case showAlert
 
         var id: RawValue {
             return rawValue
@@ -59,6 +60,9 @@ struct HomeView: View {
 
             case .checkButtons:
                 return "いろいろなButtonを使ってみる"
+
+            case .showAlert:
+                return "アラートを表示する"
             }
         }
 
@@ -93,6 +97,9 @@ struct HomeView: View {
 
             case .checkButtons:
                 CheckButtonsView()
+
+            case .showAlert:
+                ShowAlertView()
             }
         }
     }

--- a/Shared/Main/Source/Views/Home/HomeView.swift
+++ b/Shared/Main/Source/Views/Home/HomeView.swift
@@ -7,45 +7,113 @@
 
 import SwiftUI
 
+// MARK: - Main Type
+
 struct HomeView: View {
+    // MARK: Enums
+
+    enum Link: Int, CaseIterable, Identifiable {
+        case resizeImageToFit
+        case resizeImageAndClip
+        case resizeImageToCircleWithBorder
+        case imagesSideBySide
+        case hideNavigationView
+        case passValueBetweenScreens
+        case showPicker
+        case tripleTab
+        case tapThenChangeText
+        case checkButtons
+
+        var id: RawValue {
+            return rawValue
+        }
+
+        var title: String {
+            switch self {
+            case .resizeImageToFit:
+                return "画像をリサイズして表示(fit)"
+
+            case .resizeImageAndClip:
+                return "画像をリサイズして表示(clip)"
+
+            case .resizeImageToCircleWithBorder:
+                return "画像を丸く切り取り、枠を付ける"
+
+            case .imagesSideBySide:
+                return "画像を横に等間隔に並べる"
+
+            case .hideNavigationView:
+                return "NavigationViewを隠す"
+
+            case .passValueBetweenScreens:
+                return "画面遷移時に値を渡す"
+
+            case .showPicker:
+                return "Pickerを表示する"
+
+            case .tripleTab:
+                return "TabViewを使って画面を切り替える"
+
+            case .tapThenChangeText:
+                return "Buttonが押されたら文字を変える"
+
+            case .checkButtons:
+                return "いろいろなButtonを使ってみる"
+            }
+        }
+
+        @ViewBuilder var destination: some View {
+            switch self {
+            case .resizeImageToFit:
+                ResizeImageToFitView()
+
+            case .resizeImageAndClip:
+                ResizeImageAndClipView()
+
+            case .resizeImageToCircleWithBorder:
+                ResizeImageToCircleWithBorderView()
+
+            case .imagesSideBySide:
+                ImagesSideBySideView()
+
+            case .hideNavigationView:
+                HideNavigationViewView()
+
+            case .passValueBetweenScreens:
+                PassValueBetweenScreensView()
+
+            case .showPicker:
+                ShowPickerView()
+
+            case .tripleTab:
+                TripleTabView()
+
+            case .tapThenChangeText:
+                TapThenChangeTextView()
+
+            case .checkButtons:
+                CheckButtonsView()
+            }
+        }
+    }
+
+    // MARK: Body
+
     var body: some View {
         List {
             Section(header: Text("簡単")) {
-                NavigationLink(destination: ResizeImageToFitView()) {
-                    Text("画像をリサイズして表示(fit)")
-                }
-                NavigationLink(destination: ResizeImageAndClipView()) {
-                    Text("画像をリサイズして表示(clip)")
-                }
-                NavigationLink(destination: ResizeImageToCircleWithBorderView()) {
-                    Text("画像を丸く切り取り、枠を付ける")
-                }
-                NavigationLink(destination: ImagesSideBySideView()) {
-                    Text("画像を横に等間隔に並べる")
-                }
-                NavigationLink(destination: HideNavigationViewView()) {
-                    Text("NavigationViewを隠す")
-                }
-                NavigationLink(destination: PassValueBetweenScreensView()) {
-                    Text("画面遷移時に値を渡す")
-                }
-                NavigationLink(destination: ShowPickerView()) {
-                    Text("Pickerを表示する")
-                }
-                NavigationLink(destination: TripleTabView()) {
-                    Text("TabViewを使って画面を切り替える")
-                }
-                NavigationLink(destination: TapThenChangeTextView()) {
-                    Text("Buttonが押されたら文字を変える")
-                }
-                NavigationLink(destination: CheckButtonsView()) {
-                    Text("いろいろなButtonを使ってみる")
+                ForEach(Link.allCases) { link in
+                    NavigationLink(link.title) {
+                        link.destination
+                    }
                 }
             }
         }
         .navigationTitle("100本ノック")
     }
 }
+
+// MARK: - Previews
 
 struct HomeView_Previews: PreviewProvider {
     static var previews: some View {

--- a/SwiftUI100Knocks.xcodeproj/project.pbxproj
+++ b/SwiftUI100Knocks.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		46CC7CD128BBA3D40016A7A8 /* Fluit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CC7CD028BBA3D40016A7A8 /* Fluit.swift */; };
 		46CC7CD428BBA8870016A7A8 /* ShowPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CC7CD328BBA8870016A7A8 /* ShowPickerView.swift */; };
 		46CC7CD728BBAAF60016A7A8 /* Pokemon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CC7CD628BBAAF60016A7A8 /* Pokemon.swift */; };
+		46FB49CB292B9AFD00027827 /* ShowAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46FB49CA292B9AFD00027827 /* ShowAlertView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -133,6 +134,7 @@
 		46CC7CD028BBA3D40016A7A8 /* Fluit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Fluit.swift; sourceTree = "<group>"; };
 		46CC7CD328BBA8870016A7A8 /* ShowPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowPickerView.swift; sourceTree = "<group>"; };
 		46CC7CD628BBAAF60016A7A8 /* Pokemon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pokemon.swift; sourceTree = "<group>"; };
+		46FB49CA292B9AFD00027827 /* ShowAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowAlertView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -335,6 +337,7 @@
 		462034E728B0F03500540D3A /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				46FB49C9292B9AE100027827 /* Alert */,
 				460B4E9A2923CA1100B47C4F /* CheckButtons */,
 				2821269C28B9BFDF00053CEF /* HideNavigationViewView */,
 				462034E928B0F09000540D3A /* Home */,
@@ -421,6 +424,14 @@
 				46CC7CD628BBAAF60016A7A8 /* Pokemon.swift */,
 			);
 			path = Enum;
+			sourceTree = "<group>";
+		};
+		46FB49C9292B9AE100027827 /* Alert */ = {
+			isa = PBXGroup;
+			children = (
+				46FB49CA292B9AFD00027827 /* ShowAlertView.swift */,
+			);
+			path = Alert;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -680,6 +691,7 @@
 				46C82B4D28BC3A49001AFF45 /* ShowWheelPickerView.swift in Sources */,
 				463F8A5128BB967E00EC146E /* PassValueBetweenScreensView.swift in Sources */,
 				460B4E962923BDCE00B47C4F /* TabThirdView.swift in Sources */,
+				46FB49CB292B9AFD00027827 /* ShowAlertView.swift in Sources */,
 				46C83FB92924726B00B6BD4D /* NGFullWidthButtonsView.swift in Sources */,
 				280B729E28B83AAD002966AE /* ResizeImageToCircleWithBorderView.swift in Sources */,
 				46C82B4F28BC3AE4001AFF45 /* ShowMenuPickerView.swift in Sources */,


### PR DESCRIPTION
## 変更の概要

- closes #27 

## なぜこの変更をするのか

- 変更をする理由
- 前提知識がなくても分かるようにする

## やったこと

- [x] iOS 16 以降の `.alert` Modifier を使って実装した。
- [x] HomeView の NavigationLink が10個以上になり、 `Section` の許容個数を超えたため、画面遷移先を `enum` にまとめた。

## 変更内容

- UIの変更ならスクリーンショット

| Home画面 | 当画面１ | 当画面２ |
| --- | --- |  --- |
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-21 at 22 04 26](https://user-images.githubusercontent.com/35392604/203062296-1568ff5c-8c39-4a7b-84be-fa478fbcc3ef.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-21 at 22 04 30](https://user-images.githubusercontent.com/35392604/203062313-bb5c3514-9a68-4126-abe9-05a5baa1fc80.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-21 at 22 04 33](https://user-images.githubusercontent.com/35392604/203062332-6808bc55-1f91-4634-bd20-e5a02e0af9c2.png) |

- APIの変更ならリクエストとレスポンス

## 影響範囲

- ユーザに影響すること
- メンバーに影響すること
- システムに影響すること

## どうやるのか

- 使い方
- 再現手順

## 課題

- 悩んでいること
- とくにレビューしてほしいところ

## 備考

- その他に伝えたいこと
