### PR TITLE
アラートとシートを出し分ける

### DIFF
--- a/Shared/Main/Source/Views/Home/HomeView.swift
+++ b/Shared/Main/Source/Views/Home/HomeView.swift
@@ -24,6 +24,7 @@ struct HomeView: View {
         case tapThenChangeText
         case checkButtons
         case showAlert
+        case switchAlertAndSheet
 
         var id: RawValue {
             return rawValue
@@ -63,6 +64,9 @@ struct HomeView: View {
 
             case .showAlert:
                 return "アラートを表示する"
+
+            case .switchAlertAndSheet:
+                return "アラートとシートを出し分ける"
             }
         }
 
@@ -100,6 +104,9 @@ struct HomeView: View {
 
             case .showAlert:
                 ShowAlertView()
+
+            case .switchAlertAndSheet:
+                SwitchAlertAndSheetView()
             }
         }
     }

--- a/Shared/Main/Source/Views/SwitchAlertAndSheet/SwitchAlertAndSheetView.swift
+++ b/Shared/Main/Source/Views/SwitchAlertAndSheet/SwitchAlertAndSheetView.swift
@@ -7,11 +7,95 @@
 
 import SwiftUI
 
+// MARK: - Main Type
+
 struct SwitchAlertAndSheetView: View {
+    // MARK: Structs
+
+    struct ValidateErrorDetails: Identifiable {
+        let id = UUID()
+        let message: String
+    }
+
+    // MARK: Properties
+
+    @State private var inputText: String = ""
+    @State private var showSheet: Bool = false
+    @State private var didError: Bool = false
+    @State private var validateErrorDetails: ValidateErrorDetails?
+
+    private let placeholder: String = "数字を入力してください。"
+
+    // MARK: Body
+
     var body: some View {
-        Text("Hello, world.")
+        VStack(spacing: 16) {
+            TextField(
+                placeholder,
+                text: $inputText
+            )
+            .textFieldStyle(.roundedBorder)
+            .onSubmit {
+                validateErrorDetails = validate()
+                if validateErrorDetails == nil {
+                    showSheet = true
+                }
+            }
+            .textInputAutocapitalization(.never)
+            .disableAutocorrection(true)
+            .overlay(alignment: .trailing) {
+                Button {
+                    inputText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                }
+                .foregroundColor(.secondary)
+                .padding(.trailing)
+            }
+
+            Button {
+                validateErrorDetails = validate()
+                if validateErrorDetails == nil {
+                    showSheet = true
+                }
+            } label: {
+                Text("シートを表示")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+        .sheet(isPresented: $showSheet) {
+            Text("\(inputText) は数字です。")
+        }
+        .alert(
+            "エラー",
+            isPresented: $didError,
+            presenting: validateErrorDetails
+        ) { detail in
+            Button("閉じる") {
+            }
+        } message: { detail in
+            Text(detail.message)
+        }
+    }
+
+    // MARK: Private Functions
+
+    private func validate() -> ValidateErrorDetails? {
+        if inputText.isEmpty {
+            didError = true
+            return ValidateErrorDetails(message: "未入力です。入力してください。")
+        } else if Double(inputText) == nil {
+            didError = true
+            return ValidateErrorDetails(message: "\(inputText) は数字ではありません。")
+        } else {
+            return nil
+        }
     }
 }
+
+// MARK: - Previews
 
 struct SwitchAlertAndSheetView_Previews: PreviewProvider {
     static var previews: some View {

--- a/Shared/Main/Source/Views/SwitchAlertAndSheet/SwitchAlertAndSheetView.swift
+++ b/Shared/Main/Source/Views/SwitchAlertAndSheet/SwitchAlertAndSheetView.swift
@@ -1,0 +1,20 @@
+//
+//  SwitchAlertAndSheetView.swift
+//  SwiftUI100Knocks (iOS)
+//
+//  Created by 成瀬 未春 on 2022/11/21.
+//
+
+import SwiftUI
+
+struct SwitchAlertAndSheetView: View {
+    var body: some View {
+        Text("Hello, world.")
+    }
+}
+
+struct SwitchAlertAndSheetView_Previews: PreviewProvider {
+    static var previews: some View {
+        SwitchAlertAndSheetView()
+    }
+}

--- a/SwiftUI100Knocks.xcodeproj/project.pbxproj
+++ b/SwiftUI100Knocks.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		460B4E962923BDCE00B47C4F /* TabThirdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460B4E952923BDCE00B47C4F /* TabThirdView.swift */; };
 		460B4E992923C47A00B47C4F /* TapThenChangeTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460B4E982923C47A00B47C4F /* TapThenChangeTextView.swift */; };
 		460B4E9C2923CA2300B47C4F /* CheckButtonsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460B4E9B2923CA2300B47C4F /* CheckButtonsView.swift */; };
+		460CC7FF292BB0F500E996FE /* SwitchAlertAndSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 460CC7FE292BB0F500E996FE /* SwitchAlertAndSheetView.swift */; };
 		462034C128B0E46D00540D3A /* Tests_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462034C028B0E46D00540D3A /* Tests_iOS.swift */; };
 		462034C328B0E46D00540D3A /* Tests_iOSLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462034C228B0E46D00540D3A /* Tests_iOSLaunchTests.swift */; };
 		462034D028B0E46D00540D3A /* SwiftUI100KnocksApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462034A828B0E46A00540D3A /* SwiftUI100KnocksApp.swift */; };
@@ -114,6 +115,7 @@
 		460B4E952923BDCE00B47C4F /* TabThirdView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabThirdView.swift; sourceTree = "<group>"; };
 		460B4E982923C47A00B47C4F /* TapThenChangeTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapThenChangeTextView.swift; sourceTree = "<group>"; };
 		460B4E9B2923CA2300B47C4F /* CheckButtonsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckButtonsView.swift; sourceTree = "<group>"; };
+		460CC7FE292BB0F500E996FE /* SwitchAlertAndSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchAlertAndSheetView.swift; sourceTree = "<group>"; };
 		462034A828B0E46A00540D3A /* SwiftUI100KnocksApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUI100KnocksApp.swift; sourceTree = "<group>"; };
 		462034A928B0E46A00540D3A /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		462034AA28B0E46D00540D3A /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -276,6 +278,14 @@
 			path = CheckButtons;
 			sourceTree = "<group>";
 		};
+		460CC7FD292BB0DE00E996FE /* SwitchAlertAndSheet */ = {
+			isa = PBXGroup;
+			children = (
+				460CC7FE292BB0F500E996FE /* SwitchAlertAndSheetView.swift */,
+			);
+			path = SwitchAlertAndSheet;
+			sourceTree = "<group>";
+		};
 		462034A228B0E46A00540D3A = {
 			isa = PBXGroup;
 			children = (
@@ -347,6 +357,7 @@
 				280B729C28B83A87002966AE /* ResizeImageToCircleWithBorder */,
 				2870F77728B665B400718060 /* ResizeImageToFit */,
 				46CC7CD228BBA87B0016A7A8 /* ShowPicker */,
+				460CC7FD292BB0DE00E996FE /* SwitchAlertAndSheet */,
 				460B4E8D2923BB3D00B47C4F /* Tab */,
 				460B4E972923C46400B47C4F /* TapThenChangeText */,
 			);
@@ -677,6 +688,7 @@
 				46C83FB429246EF300B6BD4D /* FullWidthButtonsView.swift in Sources */,
 				2870F77C28B67A0C00718060 /* ResizeImageAndClipView.swift in Sources */,
 				46CC7CCE28BBA27D0016A7A8 /* PassValueBetweenScreensDetailView.swift in Sources */,
+				460CC7FF292BB0F500E996FE /* SwitchAlertAndSheetView.swift in Sources */,
 				287D25C228B8FF7F0000A5B7 /* ImagesSideBySideView.swift in Sources */,
 				287D25BF28B8FEA60000A5B7 /* Assets-Constants.swift in Sources */,
 				460B4E992923C47A00B47C4F /* TapThenChangeTextView.swift in Sources */,


### PR DESCRIPTION
## 変更の概要

- closes #28 

## なぜこの変更をするのか

- シートを理解する。

## やったこと

- [x] アラートとシートを出し分ける。
- [x] 未入力の場合もアラートを出す。
- [x] クリアボタンを出す。
- [x] オートコレクトと自動大文字機能を停止。

## 変更内容

- UIの変更ならスクリーンショット


https://user-images.githubusercontent.com/35392604/203539146-a35746cc-9c87-4486-b8ce-f52d278f58ee.mp4


- APIの変更ならリクエストとレスポンス

## 影響範囲

- ユーザに影響すること
- メンバーに影響すること
- システムに影響すること

## どうやるのか

- 使い方
- 再現手順

## 課題

- 悩んでいること
- とくにレビューしてほしいところ

## 備考

- その他に伝えたいこと
