### PR TITLE
Buttonからプッシュ遷移をする（NavigationLinkを無効にする）

### DIFF
--- a/Shared/Main/Source/Views/Home/HomeView.swift
+++ b/Shared/Main/Source/Views/Home/HomeView.swift
@@ -12,7 +12,8 @@ import SwiftUI
 struct HomeView: View {
     // MARK: Enums
 
-    enum Link: Int, CaseIterable, Identifiable {
+    /// 「簡単」セクションのリンク
+    enum EasySectionLink: Int, CaseIterable, Identifiable {
         case resizeImageToFit
         case resizeImageAndClip
         case resizeImageToCircleWithBorder
@@ -24,7 +25,6 @@ struct HomeView: View {
         case tapThenChangeText
         case checkButtons
         case showAlert
-        case switchAlertAndSheet
 
         var id: RawValue {
             return rawValue
@@ -64,9 +64,6 @@ struct HomeView: View {
 
             case .showAlert:
                 return "アラートを表示する"
-
-            case .switchAlertAndSheet:
-                return "アラートとシートを出し分ける"
             }
         }
 
@@ -104,9 +101,36 @@ struct HomeView: View {
 
             case .showAlert:
                 ShowAlertView()
+            }
+        }
+    }
 
+    /// 「ふつう」セクションのリンク
+    enum NormalSectionLink: Int, CaseIterable, Identifiable {
+        case switchAlertAndSheet
+        case pushFromButton
+
+        var id: RawValue {
+            return rawValue
+        }
+
+        var title: String {
+            switch self {
+            case .switchAlertAndSheet:
+                return "アラートとシートを出し分ける"
+
+            case .pushFromButton:
+                return "Buttonからプッシュ遷移をする（NavigationLinkを無効にする） "
+            }
+        }
+
+        @ViewBuilder var destination: some View {
+            switch self {
             case .switchAlertAndSheet:
                 SwitchAlertAndSheetView()
+
+            case .pushFromButton:
+                PushFromButtonView()
             }
         }
     }
@@ -116,7 +140,14 @@ struct HomeView: View {
     var body: some View {
         List {
             Section(header: Text("簡単")) {
-                ForEach(Link.allCases) { link in
+                ForEach(EasySectionLink.allCases) { link in
+                    NavigationLink(link.title) {
+                        link.destination
+                    }
+                }
+            }
+            Section(header: Text("ふつう")) {
+                ForEach(NormalSectionLink.allCases) { link in
                     NavigationLink(link.title) {
                         link.destination
                     }

--- a/Shared/Main/Source/Views/PushFromButton/PushFromButtonView.swift
+++ b/Shared/Main/Source/Views/PushFromButton/PushFromButtonView.swift
@@ -8,8 +8,18 @@
 import SwiftUI
 
 struct PushFromButtonView: View {
+    @State private var isActive: Bool = false
+
     var body: some View {
-        Text("Hello, world.")
+        Button("Tap Me") {
+            isActive = true
+        }
+
+        NavigationLink(isActive: $isActive) {
+            PushFromButtonSecondView()
+        } label: {
+            EmptyView()
+        }
     }
 }
 

--- a/Shared/Main/Source/Views/PushFromButton/PushFromButtonView.swift
+++ b/Shared/Main/Source/Views/PushFromButton/PushFromButtonView.swift
@@ -1,0 +1,20 @@
+//
+//  PushFromButtonView.swift
+//  SwiftUI100Knocks (iOS)
+//
+//  Created by 成瀬 未春 on 2022/11/23.
+//
+
+import SwiftUI
+
+struct PushFromButtonView: View {
+    var body: some View {
+        Text("Hello, world.")
+    }
+}
+
+struct PushFromButtonView_Previews: PreviewProvider {
+    static var previews: some View {
+        PushFromButtonView()
+    }
+}

--- a/Shared/Main/Source/Views/PushFromButton/Views/PushFromButtonSecondView.swift
+++ b/Shared/Main/Source/Views/PushFromButton/Views/PushFromButtonSecondView.swift
@@ -1,0 +1,20 @@
+//
+//  PushFromButtonSecondView.swift
+//  SwiftUI100Knocks (iOS)
+//
+//  Created by 成瀬 未春 on 2022/11/27.
+//
+
+import SwiftUI
+
+struct PushFromButtonSecondView: View {
+    var body: some View {
+        Text("Second View")
+    }
+}
+
+struct PushFromButtonSecondView_Previews: PreviewProvider {
+    static var previews: some View {
+        PushFromButtonSecondView()
+    }
+}

--- a/SwiftUI100Knocks.xcodeproj/project.pbxproj
+++ b/SwiftUI100Knocks.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		462034D428B0E46D00540D3A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 462034AA28B0E46D00540D3A /* Assets.xcassets */; };
 		463D8E8C292E409500E0E68F /* PushFromButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D8E8B292E409500E0E68F /* PushFromButtonView.swift */; };
 		463F8A5128BB967E00EC146E /* PassValueBetweenScreensView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463F8A5028BB967E00EC146E /* PassValueBetweenScreensView.swift */; };
+		465F5D7329330C29006638C8 /* PushFromButtonSecondView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465F5D7229330C29006638C8 /* PushFromButtonSecondView.swift */; };
 		46C82B4B28BC3A07001AFF45 /* ShowAutomaticPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C82B4A28BC3A07001AFF45 /* ShowAutomaticPickerView.swift */; };
 		46C82B4D28BC3A49001AFF45 /* ShowWheelPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C82B4C28BC3A49001AFF45 /* ShowWheelPickerView.swift */; };
 		46C82B4F28BC3AE4001AFF45 /* ShowMenuPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C82B4E28BC3AE4001AFF45 /* ShowMenuPickerView.swift */; };
@@ -126,6 +127,7 @@
 		462034C228B0E46D00540D3A /* Tests_iOSLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_iOSLaunchTests.swift; sourceTree = "<group>"; };
 		463D8E8B292E409500E0E68F /* PushFromButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushFromButtonView.swift; sourceTree = "<group>"; };
 		463F8A5028BB967E00EC146E /* PassValueBetweenScreensView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassValueBetweenScreensView.swift; sourceTree = "<group>"; };
+		465F5D7229330C29006638C8 /* PushFromButtonSecondView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushFromButtonSecondView.swift; sourceTree = "<group>"; };
 		46C82B4A28BC3A07001AFF45 /* ShowAutomaticPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowAutomaticPickerView.swift; sourceTree = "<group>"; };
 		46C82B4C28BC3A49001AFF45 /* ShowWheelPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowWheelPickerView.swift; sourceTree = "<group>"; };
 		46C82B4E28BC3AE4001AFF45 /* ShowMenuPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowMenuPickerView.swift; sourceTree = "<group>"; };
@@ -387,6 +389,7 @@
 		463D8E8A292E408A00E0E68F /* PushFromButton */ = {
 			isa = PBXGroup;
 			children = (
+				465F5D7129330C17006638C8 /* Views */,
 				463D8E8B292E409500E0E68F /* PushFromButtonView.swift */,
 			);
 			path = PushFromButton;
@@ -399,6 +402,14 @@
 				46CC7CCD28BBA27D0016A7A8 /* PassValueBetweenScreensDetailView.swift */,
 			);
 			path = PassValueBetweenScreens;
+			sourceTree = "<group>";
+		};
+		465F5D7129330C17006638C8 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				465F5D7229330C29006638C8 /* PushFromButtonSecondView.swift */,
+			);
+			path = Views;
 			sourceTree = "<group>";
 		};
 		46C82B5428BC3BD5001AFF45 /* Views */ = {
@@ -714,6 +725,7 @@
 				2821269E28B9BFF900053CEF /* HideNavigationViewView.swift in Sources */,
 				46C82B4D28BC3A49001AFF45 /* ShowWheelPickerView.swift in Sources */,
 				463F8A5128BB967E00EC146E /* PassValueBetweenScreensView.swift in Sources */,
+				465F5D7329330C29006638C8 /* PushFromButtonSecondView.swift in Sources */,
 				460B4E962923BDCE00B47C4F /* TabThirdView.swift in Sources */,
 				46FB49CB292B9AFD00027827 /* ShowAlertView.swift in Sources */,
 				46C83FB92924726B00B6BD4D /* NGFullWidthButtonsView.swift in Sources */,

--- a/SwiftUI100Knocks.xcodeproj/project.pbxproj
+++ b/SwiftUI100Knocks.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		462034D028B0E46D00540D3A /* SwiftUI100KnocksApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462034A828B0E46A00540D3A /* SwiftUI100KnocksApp.swift */; };
 		462034D228B0E46D00540D3A /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462034A928B0E46A00540D3A /* HomeView.swift */; };
 		462034D428B0E46D00540D3A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 462034AA28B0E46D00540D3A /* Assets.xcassets */; };
+		463D8E8C292E409500E0E68F /* PushFromButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463D8E8B292E409500E0E68F /* PushFromButtonView.swift */; };
 		463F8A5128BB967E00EC146E /* PassValueBetweenScreensView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 463F8A5028BB967E00EC146E /* PassValueBetweenScreensView.swift */; };
 		46C82B4B28BC3A07001AFF45 /* ShowAutomaticPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C82B4A28BC3A07001AFF45 /* ShowAutomaticPickerView.swift */; };
 		46C82B4D28BC3A49001AFF45 /* ShowWheelPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C82B4C28BC3A49001AFF45 /* ShowWheelPickerView.swift */; };
@@ -123,6 +124,7 @@
 		462034BC28B0E46D00540D3A /* Tests iOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Tests iOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		462034C028B0E46D00540D3A /* Tests_iOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_iOS.swift; sourceTree = "<group>"; };
 		462034C228B0E46D00540D3A /* Tests_iOSLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests_iOSLaunchTests.swift; sourceTree = "<group>"; };
+		463D8E8B292E409500E0E68F /* PushFromButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushFromButtonView.swift; sourceTree = "<group>"; };
 		463F8A5028BB967E00EC146E /* PassValueBetweenScreensView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassValueBetweenScreensView.swift; sourceTree = "<group>"; };
 		46C82B4A28BC3A07001AFF45 /* ShowAutomaticPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowAutomaticPickerView.swift; sourceTree = "<group>"; };
 		46C82B4C28BC3A49001AFF45 /* ShowWheelPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowWheelPickerView.swift; sourceTree = "<group>"; };
@@ -353,6 +355,7 @@
 				462034E928B0F09000540D3A /* Home */,
 				287D25C028B8FF330000A5B7 /* ImagesSideBySide */,
 				463F8A4F28BB964200EC146E /* PassValueBetweenScreens */,
+				463D8E8A292E408A00E0E68F /* PushFromButton */,
 				2870F77A28B679EC00718060 /* ResizeImageAndClip */,
 				280B729C28B83A87002966AE /* ResizeImageToCircleWithBorder */,
 				2870F77728B665B400718060 /* ResizeImageToFit */,
@@ -379,6 +382,14 @@
 				462034A928B0E46A00540D3A /* HomeView.swift */,
 			);
 			path = Home;
+			sourceTree = "<group>";
+		};
+		463D8E8A292E408A00E0E68F /* PushFromButton */ = {
+			isa = PBXGroup;
+			children = (
+				463D8E8B292E409500E0E68F /* PushFromButtonView.swift */,
+			);
+			path = PushFromButton;
 			sourceTree = "<group>";
 		};
 		463F8A4F28BB964200EC146E /* PassValueBetweenScreens */ = {
@@ -697,6 +708,7 @@
 				460B4E922923BD0200B47C4F /* TabFirstView.swift in Sources */,
 				460B4E942923BDC600B47C4F /* TabSecondView.swift in Sources */,
 				46CC7CD428BBA8870016A7A8 /* ShowPickerView.swift in Sources */,
+				463D8E8C292E409500E0E68F /* PushFromButtonView.swift in Sources */,
 				46C82B4B28BC3A07001AFF45 /* ShowAutomaticPickerView.swift in Sources */,
 				460B4E8F2923BB5E00B47C4F /* TripleTabView.swift in Sources */,
 				2821269E28B9BFF900053CEF /* HideNavigationViewView.swift in Sources */,


### PR DESCRIPTION
## 変更の概要

- closes #29

## なぜこの変更をするのか

- Buttonからプッシュ遷移をする（NavigationLinkを無効にする）方法に慣れる。

## やったこと

- [x] Buttonからプッシュ遷移をする（NavigationLinkを無効にする）
- [x] Home画面のセクションを追加

## 変更内容

- UIの変更ならスクリーンショット

| Home | 1 | 2 |
| --- | --- | --- |
| ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-27 at 12 21 45](https://user-images.githubusercontent.com/35392604/204117762-8a514599-6dda-4f9c-986f-144fad4df3a4.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-27 at 12 21 47](https://user-images.githubusercontent.com/35392604/204117763-fee27d5b-c997-4cc4-a2b3-0a9d05ee5e12.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2022-11-27 at 12 21 50](https://user-images.githubusercontent.com/35392604/204117764-388478f1-c734-4410-840a-f0f3e557b5e6.png) |

- APIの変更ならリクエストとレスポンス

## 影響範囲

- ユーザに影響すること
- メンバーに影響すること
- システムに影響すること

## どうやるのか

- 使い方
- 再現手順

## 課題

- 悩んでいること
- とくにレビューしてほしいところ

## 備考

- その他に伝えたいこと
